### PR TITLE
refs qoretechnologies/qore#5098: fix CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ default:
     - k8s
   before_script:
     - |
-        curl -s "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+        curl -s "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
         -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
         -d "{\"state\": \"pending\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
     - set +e
@@ -20,12 +20,12 @@ test-ubuntu:
   script:
     - |
         if test/docker_test/test-ubuntu.sh; then
-          curl -s "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+          curl -s "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
             -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
             -d "{\"state\": \"success\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 0
         else
-          curl -s "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+          curl -s "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
             -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
             -d "{\"state\": \"failure\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 1
@@ -37,12 +37,12 @@ test-alpine:
   script:
     - |
         if test/docker_test/test-alpine.sh; then
-          curl -s "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+          curl -s "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
             -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
             -d "{\"state\": \"success\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 0
         else
-          curl -s "https://api.github.com/repos/qorelanguage/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
+          curl -s "https://api.github.com/repos/qoretechnologies/${REPO_NAME}/statuses/${CI_COMMIT_SHA}" \
             -X POST -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" -H "Content-Type: application/json" \
             -d "{\"state\": \"failure\", \"context\": \"${REPO_NAME}\", \"description\": \"Gitlab CI\", \"target_url\": \"${CI_JOB_URL}\"}"
           exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5...3.28)
 
 project(qore-magic-module)
 


### PR DESCRIPTION
## Summary

- Fixed GitHub API org name from `qorelanguage` to `qoretechnologies` (was causing redirect)
- Updated `cmake_minimum_required` to `3.5...3.28` for Alpine compatibility (CMake < 3.5 support removed)

## Test plan

- [ ] CI should now pass on both Ubuntu and Alpine
- [ ] GitHub status should be updated correctly

## Related

- Issue: https://github.com/qoretechnologies/qore/issues/5098

🤖 Generated with [Claude Code](https://claude.com/claude-code)